### PR TITLE
PUEBI fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ Cari ```locale``` dan ```fallback_locale```, lalu ubah value menjadi ```id```
         use Laraindo\RupiahFormat; //import
 
         RupiahFormat::currency(1000000);
-        // Rp. 1.000.000
+        // Rp1.000.000
         ```
     - melalui blade
         ```php
         @RupiahFormat(1000000)
-        // Rp. 1.000.000
+        // Rp1.000.000
         ```
 - Terbilang Rupiah
     - melalui controller atau model

--- a/src/RupiahFormat.php
+++ b/src/RupiahFormat.php
@@ -61,6 +61,6 @@ class RupiahFormat
     public static function currency(mixed $value) : string
     {
         $value = floatval($value);
-        return "Rp. " . number_format($value,0,',','.');
+        return "Rp" . number_format($value,0,',','.');
     }
 }


### PR DESCRIPTION
Untuk penulisan rupiah yang benar diharuskan "Rp" didepan tanpa spasi dan titik menurut EYD dan PUEBI